### PR TITLE
Removing AxisConfiguration Parameters in Event Processor Service

### DIFF
--- a/components/event-processor/org.wso2.carbon.event.processor.admin/src/main/java/org/wso2/carbon/event/processor/admin/EventProcessorAdminService.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.admin/src/main/java/org/wso2/carbon/event/processor/admin/EventProcessorAdminService.java
@@ -46,7 +46,7 @@ public class EventProcessorAdminService extends AbstractAdmin {
 
         if (eventProcessorService != null) {
             try {
-                eventProcessorService.deployExecutionPlan(executionPlan, getAxisConfig());
+                eventProcessorService.deployExecutionPlan(executionPlan);
             } catch (ExecutionPlanConfigurationException e) {
                 log.error(e.getMessage(), e);
                 throw new AxisFault(e.getMessage(), e);
@@ -62,9 +62,8 @@ public class EventProcessorAdminService extends AbstractAdmin {
     public void undeployActiveExecutionPlan(String planName) throws AxisFault {
         EventProcessorService eventProcessorService = EventProcessorAdminValueHolder.getEventProcessorService();
         if (eventProcessorService != null) {
-            AxisConfiguration axisConfig = getAxisConfig();
             try {
-                eventProcessorService.undeployActiveExecutionPlan(planName, axisConfig);
+                eventProcessorService.undeployActiveExecutionPlan(planName);
             } catch (ExecutionPlanConfigurationException e) {
                 log.error(e.getMessage(), e);
                 throw new AxisFault(e.getMessage());
@@ -75,9 +74,8 @@ public class EventProcessorAdminService extends AbstractAdmin {
     public void undeployInactiveExecutionPlan(String fileName) throws AxisFault {
         EventProcessorService eventProcessorService = EventProcessorAdminValueHolder.getEventProcessorService();
         if (eventProcessorService != null) {
-            AxisConfiguration axisConfig = getAxisConfig();
             try {
-                eventProcessorService.undeployInactiveExecutionPlan(fileName, axisConfig);
+                eventProcessorService.undeployInactiveExecutionPlan(fileName);
             } catch (ExecutionPlanConfigurationException e) {
                 log.error(e.getMessage(), e);
                 throw new AxisFault(e.getMessage(), e);
@@ -88,9 +86,8 @@ public class EventProcessorAdminService extends AbstractAdmin {
     public void editActiveExecutionPlan(String executionPlan, String name)
             throws AxisFault {
         EventProcessorService eventProcessorService = EventProcessorAdminValueHolder.getEventProcessorService();
-        AxisConfiguration axisConfig = getAxisConfig();
         try {
-            eventProcessorService.editActiveExecutionPlan(executionPlan, name, axisConfig);
+            eventProcessorService.editActiveExecutionPlan(executionPlan, name);
         } catch (ExecutionPlanConfigurationException e) {
             log.error(e.getMessage(), e);
             throw new AxisFault(e.getMessage(), e);
@@ -103,9 +100,8 @@ public class EventProcessorAdminService extends AbstractAdmin {
     public void editInactiveExecutionPlan(String executionPlan, String fileName)
             throws AxisFault {
         EventProcessorService eventProcessorService = EventProcessorAdminValueHolder.getEventProcessorService();
-        AxisConfiguration axisConfig = getAxisConfig();
         try {
-            eventProcessorService.editInactiveExecutionPlan(executionPlan, fileName, axisConfig);
+            eventProcessorService.editInactiveExecutionPlan(executionPlan, fileName);
         } catch (ExecutionPlanConfigurationException e) {
             log.error(e.getMessage(), e);
             throw new AxisFault(e.getMessage(), e);
@@ -130,9 +126,8 @@ public class EventProcessorAdminService extends AbstractAdmin {
 
     public String getActiveExecutionPlan(String planName) throws AxisFault {
         EventProcessorService eventProcessorService = EventProcessorAdminValueHolder.getEventProcessorService();
-        AxisConfiguration axisConfig = getAxisConfig();
         try {
-            return eventProcessorService.getActiveExecutionPlan(planName, axisConfig);
+            return eventProcessorService.getActiveExecutionPlan(planName);
         } catch (ExecutionPlanConfigurationException e) {
             log.error(e.getMessage(), e);
             throw new AxisFault(e.getMessage(), e);
@@ -141,9 +136,8 @@ public class EventProcessorAdminService extends AbstractAdmin {
 
     public String getInactiveExecutionPlan(String filename) throws AxisFault {
         EventProcessorService eventProcessorService = EventProcessorAdminValueHolder.getEventProcessorService();
-        AxisConfiguration axisConfig = getAxisConfig();
         try {
-            return eventProcessorService.getInactiveExecutionPlan(filename, axisConfig);
+            return eventProcessorService.getInactiveExecutionPlan(filename);
         } catch (ExecutionPlanConfigurationException e) {
             log.error(e.getMessage(), e);
             throw new AxisFault(e.getMessage(), e);
@@ -253,9 +247,8 @@ public class EventProcessorAdminService extends AbstractAdmin {
     public void setTracingEnabled(String executionPlanName, boolean isEnabled) throws AxisFault {
         EventProcessorService eventProcessorService = EventProcessorAdminValueHolder.getEventProcessorService();
         if (eventProcessorService != null) {
-            AxisConfiguration axisConfig = getAxisConfig();
             try {
-                eventProcessorService.setTracingEnabled(executionPlanName, isEnabled, axisConfig);
+                eventProcessorService.setTracingEnabled(executionPlanName, isEnabled);
             } catch (ExecutionPlanConfigurationException e) {
                 log.error(e.getMessage(), e);
                 throw new AxisFault(e.getMessage(), e);
@@ -268,9 +261,8 @@ public class EventProcessorAdminService extends AbstractAdmin {
     public void setStatisticsEnabled(String executionPlanName, boolean isEnabled) throws AxisFault {
         EventProcessorService eventProcessorService = EventProcessorAdminValueHolder.getEventProcessorService();
         if (eventProcessorService != null) {
-            AxisConfiguration axisConfig = getAxisConfig();
             try {
-                eventProcessorService.setStatisticsEnabled(executionPlanName, isEnabled, axisConfig);
+                eventProcessorService.setStatisticsEnabled(executionPlanName, isEnabled);
             } catch (ExecutionPlanConfigurationException e) {
                 log.error(e.getMessage(), e);
                 throw new AxisFault(e.getMessage(), e);

--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/EventProcessorDeployer.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/EventProcessorDeployer.java
@@ -58,7 +58,6 @@ public class EventProcessorDeployer extends AbstractDeployer implements EventPro
      *
      * @param deploymentFileData information about query plan
      * @throws org.apache.axis2.deployment.DeploymentException
-     *
      */
     public void deploy(DeploymentFileData deploymentFileData) throws DeploymentException {
         try {
@@ -89,7 +88,6 @@ public class EventProcessorDeployer extends AbstractDeployer implements EventPro
      *
      * @param filePath the path to the bucket to be removed
      * @throws org.apache.axis2.deployment.DeploymentException
-     *
      */
     public void undeploy(String filePath) throws DeploymentException {
         try {
@@ -112,7 +110,7 @@ public class EventProcessorDeployer extends AbstractDeployer implements EventPro
         CarbonEventProcessorService carbonEventProcessorService = EventProcessorValueHolder.getEventProcessorService();
 
         File executionPlanFile = deploymentFileData.getFile();
-        boolean isEditable = !executionPlanFile.getAbsolutePath().contains(File.separator+ "carbonapps" + File.separator);
+        boolean isEditable = !executionPlanFile.getAbsolutePath().contains(File.separator + "carbonapps" + File.separator);
         int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
         ExecutionPlanConfigurationFile executionPlanConfigurationFile = new ExecutionPlanConfigurationFile();
         if (!carbonEventProcessorService.isExecutionPlanFileAlreadyExist(executionPlanFile.getName(), tenantId)) {
@@ -122,7 +120,7 @@ public class EventProcessorDeployer extends AbstractDeployer implements EventPro
                 EventProcessorHelper.validateExecutionPlan(executionPlan, tenantId);
 
                 executionPlanName = EventProcessorHelper.getExecutionPlanName(executionPlan);
-                carbonEventProcessorService.addExecutionPlan(executionPlan, isEditable, configurationContext.getAxisConfiguration());
+                carbonEventProcessorService.addExecutionPlan(executionPlan, isEditable);
                 executionPlanConfigurationFile.setStatus(ExecutionPlanConfigurationFile.Status.DEPLOYED);
                 executionPlanConfigurationFile.setExecutionPlanName(executionPlanName);
                 executionPlanConfigurationFile.setAxisConfiguration(configurationContext.getAxisConfiguration());
@@ -209,14 +207,14 @@ public class EventProcessorDeployer extends AbstractDeployer implements EventPro
             }
             return sb.toString();
         } catch (FileNotFoundException e) {
-            throw new ExecutionPlanConfigurationException("File '"+ path +"' not found."+ e.getMessage(), e);
+            throw new ExecutionPlanConfigurationException("File '" + path + "' not found." + e.getMessage(), e);
         } catch (IOException e) {
-            throw new ExecutionPlanConfigurationException("Could not read from file "+ path +", "+ e.getMessage(), e);
+            throw new ExecutionPlanConfigurationException("Could not read from file " + path + ", " + e.getMessage(), e);
         } finally {
             try {
                 br.close();
             } catch (IOException e) {
-                throw new ExecutionPlanConfigurationException("Could not close the file "+ path +", "+ e.getMessage(), e);
+                throw new ExecutionPlanConfigurationException("Could not close the file " + path + ", " + e.getMessage(), e);
             }
         }
     }

--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/EventProcessorService.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/EventProcessorService.java
@@ -17,7 +17,6 @@
 */
 package org.wso2.carbon.event.processor.core;
 
-import org.apache.axis2.engine.AxisConfiguration;
 import org.wso2.carbon.databridge.commons.StreamDefinition;
 import org.wso2.carbon.event.processor.core.exception.ExecutionPlanConfigurationException;
 import org.wso2.carbon.event.processor.core.exception.ExecutionPlanDependencyValidationException;
@@ -34,41 +33,33 @@ public interface EventProcessorService {
      *
      * @param executionPlan new execution plan as a string
      */
-    public void deployExecutionPlan(
-            String executionPlan,
-            AxisConfiguration axisConfiguration)
+    public void deployExecutionPlan(String executionPlan)
             throws ExecutionPlanDependencyValidationException, ExecutionPlanConfigurationException;
 
     /**
      * Removes execution plan from the system
      *
      * @param fileName name of the file which contains the execution plan
-     * @param axisConfiguration the axis configuration associated with the caller
      */
-    public void undeployInactiveExecutionPlan(String fileName,
-                                              AxisConfiguration axisConfiguration) throws
+    public void undeployInactiveExecutionPlan(String fileName) throws
             ExecutionPlanConfigurationException;
 
     /**
      * Removes execution plan from the system
      *
      * @param planName name of the execution plan
-     * @param axisConfiguration the axis configuration associated with the caller
      */
-    public void undeployActiveExecutionPlan(String planName,
-                                            AxisConfiguration axisConfiguration) throws
+    public void undeployActiveExecutionPlan(String planName) throws
             ExecutionPlanConfigurationException;
 
     /**
      * Edits execution plan from the system
      *
-     * @param executionPlan the execution plan configuration as an XML string
+     * @param executionPlan     the execution plan configuration as an XML string
      * @param executionPlanName the name of the execution plan
-     * @param axisConfiguration the axis configuration associated with the caller
      */
     public void editActiveExecutionPlan(String executionPlan,
-                                        String executionPlanName,
-                                        AxisConfiguration axisConfiguration)
+                                        String executionPlanName)
             throws ExecutionPlanConfigurationException, ExecutionPlanDependencyValidationException;
 
 
@@ -76,34 +67,30 @@ public interface EventProcessorService {
      * Edits execution plan from the system
      *
      * @param executionPlan the execution plan configuration as an XML string
-     * @param fileName filename of the configuration for this execution plan
-     * @param axisConfiguration the axis configuration associated with the caller
+     * @param fileName      filename of the configuration for this execution plan
      */
     public void editInactiveExecutionPlan(String executionPlan,
-                                          String fileName,
-                                          AxisConfiguration axisConfiguration)
+                                          String fileName)
             throws ExecutionPlanConfigurationException, ExecutionPlanDependencyValidationException;
 
     /**
      * Returns the content of the execution plan identified by the name as an XML string
      *
      * @param name the name of the execution plan
-     * @param axisConfiguration the axis configuration associated with the caller
      * @return the content of the exeuction plan configuration
      * @throws ExecutionPlanConfigurationException
      */
-    public String getActiveExecutionPlan(String name, AxisConfiguration axisConfiguration)
+    public String getActiveExecutionPlan(String name)
             throws ExecutionPlanConfigurationException;
 
     /**
      * Returns the file content for the filename specified as a string
      *
      * @param filename filename of the configuration for this execution plan
-     * @param axisConfiguration the axis configuration associated with the caller
      * @return the content of the specified filename
      * @throws ExecutionPlanConfigurationException
      */
-    public String getInactiveExecutionPlan(String filename, AxisConfiguration axisConfiguration)
+    public String getInactiveExecutionPlan(String filename)
             throws ExecutionPlanConfigurationException;
 
 
@@ -116,20 +103,18 @@ public interface EventProcessorService {
     public Map<String, ExecutionPlanConfiguration> getAllActiveExecutionConfigurations(int tenantId);
 
     /**
-     *
      * @param tenantId tenant id of the caller
      * @param streamId
      * @return
      */
-    public Map<String, ExecutionPlanConfiguration> getAllExportedStreamSpecificActiveExecutionConfigurations(int tenantId,String streamId);
+    public Map<String, ExecutionPlanConfiguration> getAllExportedStreamSpecificActiveExecutionConfigurations(int tenantId, String streamId);
 
     /**
-     *
      * @param tenantId tenant id of the caller
      * @param streamId
      * @return
      */
-    public Map<String, ExecutionPlanConfiguration> getAllImportedStreamSpecificActiveExecutionConfigurations(int tenantId,String streamId);
+    public Map<String, ExecutionPlanConfiguration> getAllImportedStreamSpecificActiveExecutionConfigurations(int tenantId, String streamId);
 
 
     /**
@@ -147,31 +132,25 @@ public interface EventProcessorService {
      *
      * @param tenantId tenant id of the caller
      * @return A {@link List} of {@link ExecutionPlanConfigurationFile} objects for all the inactive execution plans
-     *  for the specified tenant id
+     * for the specified tenant id
      */
     public List<ExecutionPlanConfigurationFile> getAllInactiveExecutionPlanConfiguration(
             int tenantId);
 
     /**
-     *
      * @param executionPlanName the name of the execution plan
-     * @param isEnabled whether tracing is enabled or not
-     * @param axisConfiguration the axis configuration associated with the caller
+     * @param isEnabled         whether tracing is enabled or not
      * @throws ExecutionPlanConfigurationException
      */
-    public void setTracingEnabled(String executionPlanName, boolean isEnabled,
-                           AxisConfiguration axisConfiguration)
+    public void setTracingEnabled(String executionPlanName, boolean isEnabled)
             throws ExecutionPlanConfigurationException;
 
     /**
-     *
      * @param executionPlanName the name of the execution plan
-     * @param isEnabled whether statistics is enabled or not
-     * @param axisConfiguration the axis configuration associated with the caller
+     * @param isEnabled         whether statistics is enabled or not
      * @throws ExecutionPlanConfigurationException
      */
-    public void setStatisticsEnabled(String executionPlanName, boolean isEnabled,
-                              AxisConfiguration axisConfiguration)
+    public void setStatisticsEnabled(String executionPlanName, boolean isEnabled)
             throws ExecutionPlanConfigurationException;
 
 
@@ -179,12 +158,14 @@ public interface EventProcessorService {
      * Validates a given execution plan. returns true if valid.
      *
      * @param executionPlan execution plan.
-     * @return  true if valid.
+     * @return true if valid.
      */
-    public void validateExecutionPlan(String executionPlan) throws ExecutionPlanConfigurationException, ExecutionPlanDependencyValidationException;
+    public void validateExecutionPlan(String executionPlan)
+            throws ExecutionPlanConfigurationException, ExecutionPlanDependencyValidationException;
 
     /**
      * Fetches all the streams imported and exported by the Siddhi engine for the given execution plan.
+     *
      * @param executionPlan siddhi queries.
      * @return a {@link List} of {@link StreamDefinition} objects that represent all the streams imported and exported by Siddhi queries
      * @throws SiddhiParserException

--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/util/EventProcessorConfigurationFilesystemInvoker.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/util/EventProcessorConfigurationFilesystemInvoker.java
@@ -35,18 +35,16 @@ public class EventProcessorConfigurationFilesystemInvoker {
 
     public static void save(OMElement executionPlanOM,
                             String executionPlanName,
-                            String fileName,
-                            AxisConfiguration axisConfiguration)
+                            String fileName)
             throws ExecutionPlanConfigurationException {
 
-        EventProcessorConfigurationFilesystemInvoker.saveOld(executionPlanOM.toString(), executionPlanName, fileName, axisConfiguration);
+        EventProcessorConfigurationFilesystemInvoker.saveOld(executionPlanOM.toString(), executionPlanName, fileName);
     }
 
-    public static void saveOld(String executionPlan, String executionPlanName,
-                               String fileName, AxisConfiguration axisConfiguration)
+    public static void saveOld(String executionPlan, String executionPlanName, String fileName)
             throws ExecutionPlanConfigurationException {
-        EventProcessorDeployer eventProcessorDeployer = (EventProcessorDeployer) getDeployer(axisConfiguration, EventProcessorConstants.EP_ELE_DIRECTORY);
-        String filePath = getFilePathFromFilename(fileName, axisConfiguration);
+        EventProcessorDeployer eventProcessorDeployer = (EventProcessorDeployer) getDeployer(EventProcessorConstants.EP_ELE_DIRECTORY);
+        String filePath = getFilePathFromFilename(fileName);
         try {
             OutputStreamWriter writer = null;
             try {
@@ -74,11 +72,10 @@ public class EventProcessorConfigurationFilesystemInvoker {
         }
     }
 
-    public static void save(String executionPlan, String executionPlanName,
-                               String fileName, AxisConfiguration axisConfiguration)
+    public static void save(String executionPlan, String executionPlanName, String fileName)
             throws ExecutionPlanConfigurationException {
-        EventProcessorDeployer eventProcessorDeployer = (EventProcessorDeployer) getDeployer(axisConfiguration, EventProcessorConstants.EP_ELE_DIRECTORY);
-        String filePath = getFilePathFromFilename(fileName, axisConfiguration);
+        EventProcessorDeployer eventProcessorDeployer = (EventProcessorDeployer) getDeployer(EventProcessorConstants.EP_ELE_DIRECTORY);
+        String filePath = getFilePathFromFilename(fileName);
         try {
             OutputStreamWriter writer = null;
             try {
@@ -106,13 +103,13 @@ public class EventProcessorConfigurationFilesystemInvoker {
         }
     }
 
-    public static void delete(String fileName, AxisConfiguration axisConfiguration)
+    public static void delete(String fileName)
             throws ExecutionPlanConfigurationException {
         try {
-            String filePath=getFilePathFromFilename(fileName,axisConfiguration);
+            String filePath = getFilePathFromFilename(fileName);
             File file = new File(filePath);
             if (file.exists()) {
-                EventProcessorDeployer deployer = (EventProcessorDeployer) getDeployer(axisConfiguration, EventProcessorConstants.EP_ELE_DIRECTORY);
+                EventProcessorDeployer deployer = (EventProcessorDeployer) getDeployer(EventProcessorConstants.EP_ELE_DIRECTORY);
                 deployer.getUnDeployedExecutionPlanFilePaths().add(filePath);
                 boolean fileDeleted = file.delete();
                 if (!fileDeleted) {
@@ -129,7 +126,7 @@ public class EventProcessorConfigurationFilesystemInvoker {
     }
 
     public static void reload(String filePath, AxisConfiguration axisConfiguration) throws ExecutionPlanConfigurationException {
-        EventProcessorDeployer eventProcessorDeployer = (EventProcessorDeployer) getDeployer(axisConfiguration, EventProcessorConstants.EP_ELE_DIRECTORY);
+        EventProcessorDeployer eventProcessorDeployer = (EventProcessorDeployer) getDeployer(EventProcessorConstants.EP_ELE_DIRECTORY);
         try {
             eventProcessorDeployer.processUndeploy(filePath);
             eventProcessorDeployer.processDeploy(new DeploymentFileData(new File(filePath)));
@@ -139,22 +136,22 @@ public class EventProcessorConfigurationFilesystemInvoker {
 
     }
 
-    public static Deployer getDeployer(AxisConfiguration axisConfig, String endpointDirPath) {
-        DeploymentEngine deploymentEngine = (DeploymentEngine) axisConfig.getConfigurator();
+    public static Deployer getDeployer(String endpointDirPath) {
+        DeploymentEngine deploymentEngine = (DeploymentEngine) EventProcessorUtil.getAxisConfiguration().getConfigurator();
         return deploymentEngine.getDeployer(endpointDirPath, "siddhiql");
     }
 
 
-    private static String getFilePathFromFilename(String fileName, AxisConfiguration axisConfiguration) {
-        return  new File(axisConfiguration.getRepository().getPath()).getAbsolutePath() + File.separator + EventProcessorConstants.EP_ELE_DIRECTORY + File.separator + fileName;
+    private static String getFilePathFromFilename(String fileName) {
+        return new File(EventProcessorUtil.getAxisConfiguration().getRepository().getPath()).getAbsolutePath() + File.separator + EventProcessorConstants.EP_ELE_DIRECTORY + File.separator + fileName;
     }
 
-    public static String readExecutionPlanConfigFile(String fileName, AxisConfiguration axisConfiguration)
+    public static String readExecutionPlanConfigFile(String fileName)
             throws ExecutionPlanConfigurationException {
         BufferedReader bufferedReader = null;
         StringBuilder stringBuilder = new StringBuilder();
         try {
-            String filePath = getFilePathFromFilename(fileName, axisConfiguration);
+            String filePath = getFilePathFromFilename(fileName);
             bufferedReader = new BufferedReader(new FileReader(filePath));
             String line = null;
             while ((line = bufferedReader.readLine()) != null) {
@@ -175,6 +172,4 @@ public class EventProcessorConfigurationFilesystemInvoker {
         }
         return stringBuilder.toString().trim();
     }
-
-
 }

--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/util/EventProcessorUtil.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/util/EventProcessorUtil.java
@@ -17,16 +17,21 @@
  */
 package org.wso2.carbon.event.processor.core.internal.util;
 
+import org.apache.axis2.engine.AxisConfiguration;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.xml.serialize.OutputFormat;
 import org.apache.xml.serialize.XMLSerializer;
 import org.w3c.dom.Document;
+import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.core.multitenancy.utils.TenantAxisUtils;
 import org.wso2.carbon.databridge.commons.AttributeType;
 import org.wso2.carbon.databridge.commons.StreamDefinition;
 import org.wso2.carbon.databridge.commons.exception.MalformedStreamDefinitionException;
 import org.wso2.carbon.event.processor.core.StreamConfiguration;
 import org.wso2.carbon.event.processor.core.exception.ExecutionPlanConfigurationException;
+import org.wso2.carbon.event.processor.core.internal.ds.EventProcessorValueHolder;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.siddhi.core.util.SiddhiConstants;
 import org.wso2.siddhi.query.api.definition.Attribute;
 import org.xml.sax.InputSource;
@@ -278,5 +283,19 @@ public class EventProcessorUtil {
         }
         builder.append(queryExpressions);
         return builder.toString();
+    }
+
+    public static AxisConfiguration getAxisConfiguration() {
+        AxisConfiguration axisConfiguration = null;
+        if (CarbonContext.getThreadLocalCarbonContext().getTenantId() == MultitenantConstants.SUPER_TENANT_ID) {
+            axisConfiguration = EventProcessorValueHolder.getConfigurationContext().
+                    getServerConfigContext().getAxisConfiguration();
+        } else {
+            axisConfiguration = TenantAxisUtils.getTenantAxisConfiguration(CarbonContext.
+                            getThreadLocalCarbonContext().getTenantDomain(),
+                    EventProcessorValueHolder.getConfigurationContext().
+                            getServerConfigContext());
+        }
+        return axisConfiguration;
     }
 }


### PR DESCRIPTION
Removing AxisConfiguration as Parameters in Event Processor Service operations. Instead get AxisConfiguration within the Event Processor Service itself.

JIRA : https://wso2.org/jira/browse/CEP-1086