### PR TITLE
Removing TenantId Parameters in Event Processor Service

### DIFF
--- a/components/event-flow/org.wso2.carbon.event.flow/src/main/java/org/wso2/carbon/event/flow/EventFlowAdminService.java
+++ b/components/event-flow/org.wso2.carbon.event.flow/src/main/java/org/wso2/carbon/event/flow/EventFlowAdminService.java
@@ -43,7 +43,7 @@ public class EventFlowAdminService extends AbstractAdmin {
             List<EventReceiverConfiguration> eventReceiverConfigurations = EventFlowServiceValueHolder.getEventReceiverService().getAllActiveEventReceiverConfigurations();
             List<EventPublisherConfiguration> eventPublisherConfigurations = EventFlowServiceValueHolder.getEventPublisherService().getAllActiveEventPublisherConfigurations();
             List<String> streamIds = EventFlowServiceValueHolder.getEventStreamService().getStreamIds();
-            Map<String, ExecutionPlanConfiguration> executionPlanConfigurations = EventFlowServiceValueHolder.getEventProcessorService().getAllActiveExecutionConfigurations(tenantId);
+            Map<String, ExecutionPlanConfiguration> executionPlanConfigurations = EventFlowServiceValueHolder.getEventProcessorService().getAllActiveExecutionConfigurations();
 
             StringBuilder eventFlow = new StringBuilder(" '{ \"nodes\": [ ");
             for (EventReceiverConfiguration receiverConfiguration : eventReceiverConfigurations) {

--- a/components/event-processor/org.wso2.carbon.event.processor.admin/src/main/java/org/wso2/carbon/event/processor/admin/EventProcessorAdminService.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.admin/src/main/java/org/wso2/carbon/event/processor/admin/EventProcessorAdminService.java
@@ -117,8 +117,7 @@ public class EventProcessorAdminService extends AbstractAdmin {
             throws AxisFault {
         EventProcessorService eventProcessorService = EventProcessorAdminValueHolder.getEventProcessorService();
         if (eventProcessorService != null) {
-            ExecutionPlanConfiguration executionConfiguration = eventProcessorService.getActiveExecutionPlanConfiguration(planName,
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId());
+            ExecutionPlanConfiguration executionConfiguration = eventProcessorService.getActiveExecutionPlanConfiguration(planName);
             ExecutionPlanConfigurationDto dto = new ExecutionPlanConfigurationDto();
             copyConfigurationsToDto(executionConfiguration, dto);
             return dto;
@@ -152,8 +151,7 @@ public class EventProcessorAdminService extends AbstractAdmin {
         EventProcessorService eventProcessorService = EventProcessorAdminValueHolder.getEventProcessorService();
         if (eventProcessorService != null) {
 
-            Map<String, ExecutionPlanConfiguration> executionPlanConfigurations = eventProcessorService.getAllActiveExecutionConfigurations(
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId());
+            Map<String, ExecutionPlanConfiguration> executionPlanConfigurations = eventProcessorService.getAllActiveExecutionConfigurations();
             if (executionPlanConfigurations != null) {
                 ExecutionPlanConfigurationDto[] configurationDtos = new ExecutionPlanConfigurationDto[executionPlanConfigurations.size()];
 
@@ -182,7 +180,7 @@ public class EventProcessorAdminService extends AbstractAdmin {
         EventProcessorService eventProcessorService = EventProcessorAdminValueHolder.getEventProcessorService();
         if (eventProcessorService != null) {
             int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
-            List<ExecutionPlanConfigurationFile> files = eventProcessorService.getAllInactiveExecutionPlanConfiguration(tenantId);
+            List<ExecutionPlanConfigurationFile> files = eventProcessorService.getAllInactiveExecutionPlanConfiguration();
             if (files != null) {
                 ExecutionPlanConfigurationFileDto[] fileDtoArray = new ExecutionPlanConfigurationFileDto[files.size()];
                 for (int i = 0; i < files.size(); i++) {
@@ -219,7 +217,7 @@ public class EventProcessorAdminService extends AbstractAdmin {
         if (eventProcessorService != null) {
 
             Map<String, ExecutionPlanConfiguration> executionPlanConfigurations = eventProcessorService.
-                    getAllExportedStreamSpecificActiveExecutionConfigurations(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId(), streamId);
+                    getAllExportedStreamSpecificActiveExecutionConfigurations(streamId);
             if (executionPlanConfigurations != null) {
                 ExecutionPlanConfigurationDto[] configurationDtos = new ExecutionPlanConfigurationDto[executionPlanConfigurations.size()];
 
@@ -250,7 +248,7 @@ public class EventProcessorAdminService extends AbstractAdmin {
         if (eventProcessorService != null) {
 
             Map<String, ExecutionPlanConfiguration> executionPlanConfigurations = eventProcessorService.
-                    getAllImportedStreamSpecificActiveExecutionConfigurations(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId(), streamId);
+                    getAllImportedStreamSpecificActiveExecutionConfigurations(streamId);
             if (executionPlanConfigurations != null) {
                 ExecutionPlanConfigurationDto[] configurationDtos = new ExecutionPlanConfigurationDto[executionPlanConfigurations.size()];
 

--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/EventProcessorDeployer.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/EventProcessorDeployer.java
@@ -113,11 +113,11 @@ public class EventProcessorDeployer extends AbstractDeployer implements EventPro
         boolean isEditable = !executionPlanFile.getAbsolutePath().contains(File.separator + "carbonapps" + File.separator);
         int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
         ExecutionPlanConfigurationFile executionPlanConfigurationFile = new ExecutionPlanConfigurationFile();
-        if (!carbonEventProcessorService.isExecutionPlanFileAlreadyExist(executionPlanFile.getName(), tenantId)) {
+        if (!carbonEventProcessorService.isExecutionPlanFileAlreadyExist(executionPlanFile.getName())) {
             String executionPlanName = "";
             try {
                 String executionPlan = readFile(deploymentFileData.getAbsolutePath());
-                EventProcessorHelper.validateExecutionPlan(executionPlan, tenantId);
+                EventProcessorHelper.validateExecutionPlan(executionPlan);
 
                 executionPlanName = EventProcessorHelper.getExecutionPlanName(executionPlan);
                 carbonEventProcessorService.addExecutionPlan(executionPlan, isEditable);
@@ -126,7 +126,7 @@ public class EventProcessorDeployer extends AbstractDeployer implements EventPro
                 executionPlanConfigurationFile.setAxisConfiguration(configurationContext.getAxisConfiguration());
                 executionPlanConfigurationFile.setFileName(deploymentFileData.getName());
                 executionPlanConfigurationFile.setFilePath(deploymentFileData.getAbsolutePath());
-                carbonEventProcessorService.addExecutionPlanConfigurationFile(executionPlanConfigurationFile, PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId());
+                carbonEventProcessorService.addExecutionPlanConfigurationFile(executionPlanConfigurationFile);
 
                 log.info("Execution plan is deployed successfully and in active state  : " + executionPlanName);
 
@@ -138,7 +138,7 @@ public class EventProcessorDeployer extends AbstractDeployer implements EventPro
                 executionPlanConfigurationFile.setAxisConfiguration(configurationContext.getAxisConfiguration());
                 executionPlanConfigurationFile.setFileName(deploymentFileData.getName());
                 executionPlanConfigurationFile.setFilePath(deploymentFileData.getAbsolutePath());
-                carbonEventProcessorService.addExecutionPlanConfigurationFile(executionPlanConfigurationFile, PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId());
+                carbonEventProcessorService.addExecutionPlanConfigurationFile(executionPlanConfigurationFile);
 
                 log.info("Execution plan deployment held back and in inactive state : " + executionPlanName + ", waiting for dependency : " + ex.getDependency());
 
@@ -150,7 +150,7 @@ public class EventProcessorDeployer extends AbstractDeployer implements EventPro
                 executionPlanConfigurationFile.setAxisConfiguration(configurationContext.getAxisConfiguration());
                 executionPlanConfigurationFile.setFileName(deploymentFileData.getName());
                 executionPlanConfigurationFile.setFilePath(deploymentFileData.getAbsolutePath());
-                carbonEventProcessorService.addExecutionPlanConfigurationFile(executionPlanConfigurationFile, PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId());
+                carbonEventProcessorService.addExecutionPlanConfigurationFile(executionPlanConfigurationFile);
 
                 log.info("Execution plan deployment held back and in inactive state : " + executionPlanName + ", waiting for dependency : " + ex.getDependency());
 
@@ -161,7 +161,7 @@ public class EventProcessorDeployer extends AbstractDeployer implements EventPro
                 executionPlanConfigurationFile.setAxisConfiguration(configurationContext.getAxisConfiguration());
                 executionPlanConfigurationFile.setFileName(deploymentFileData.getName());
                 executionPlanConfigurationFile.setFilePath(deploymentFileData.getAbsolutePath());
-                carbonEventProcessorService.addExecutionPlanConfigurationFile(executionPlanConfigurationFile, PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId());
+                carbonEventProcessorService.addExecutionPlanConfigurationFile(executionPlanConfigurationFile);
 
                 log.error("Execution plan is not deployed and in inactive state : " + executionPlanFile.getName(), ex);
                 throw new ExecutionPlanConfigurationException(ex.getMessage(), ex);
@@ -179,7 +179,7 @@ public class EventProcessorDeployer extends AbstractDeployer implements EventPro
         int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
         CarbonEventProcessorService carbonEventProcessorService = EventProcessorValueHolder.getEventProcessorService();
         AxisConfiguration axisConfiguration = configurationContext.getAxisConfiguration();
-        carbonEventProcessorService.removeExecutionPlanConfigurationFile(fileName, tenantId);
+        carbonEventProcessorService.removeExecutionPlanConfigurationFile(fileName);
     }
 
     public void setDirectory(String directory) {

--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/EventProcessorService.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/EventProcessorService.java
@@ -97,45 +97,38 @@ public interface EventProcessorService {
     /**
      * Gets all available active execution plan configurations.
      *
-     * @param tenantId tenant id of the caller
      * @return a {@link Map} of execution plan name and {@link ExecutionPlanConfiguration} object of active execution plans.
      */
-    public Map<String, ExecutionPlanConfiguration> getAllActiveExecutionConfigurations(int tenantId);
+    public Map<String, ExecutionPlanConfiguration> getAllActiveExecutionConfigurations();
 
     /**
-     * @param tenantId tenant id of the caller
      * @param streamId
      * @return
      */
-    public Map<String, ExecutionPlanConfiguration> getAllExportedStreamSpecificActiveExecutionConfigurations(int tenantId, String streamId);
+    public Map<String, ExecutionPlanConfiguration> getAllExportedStreamSpecificActiveExecutionConfigurations(String streamId);
 
     /**
-     * @param tenantId tenant id of the caller
      * @param streamId
      * @return
      */
-    public Map<String, ExecutionPlanConfiguration> getAllImportedStreamSpecificActiveExecutionConfigurations(int tenantId, String streamId);
+    public Map<String, ExecutionPlanConfiguration> getAllImportedStreamSpecificActiveExecutionConfigurations(String streamId);
 
 
     /**
      * Gets an active execution plan configuration for the name passed in.
      *
      * @param planName the name of the execution plan
-     * @param tenantId tenant id of the caller
-     * @return {@link ExecutionPlanConfiguration} object associated with the passed in name and tenant id
+     * @return {@link ExecutionPlanConfiguration} object associated with the passed in name
      */
-    public ExecutionPlanConfiguration getActiveExecutionPlanConfiguration(String planName, int tenantId);
+    public ExecutionPlanConfiguration getActiveExecutionPlanConfiguration(String planName);
 
 
     /**
      * Gets all available inactive execution plan configurations files.
      *
-     * @param tenantId tenant id of the caller
      * @return A {@link List} of {@link ExecutionPlanConfigurationFile} objects for all the inactive execution plans
-     * for the specified tenant id
      */
-    public List<ExecutionPlanConfigurationFile> getAllInactiveExecutionPlanConfiguration(
-            int tenantId);
+    public List<ExecutionPlanConfigurationFile> getAllInactiveExecutionPlanConfiguration();
 
     /**
      * @param executionPlanName the name of the execution plan

--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/listener/EventStreamListenerImpl.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/listener/EventStreamListenerImpl.java
@@ -29,12 +29,13 @@ import org.wso2.carbon.event.stream.core.EventStreamListener;
 public class EventStreamListenerImpl implements EventStreamListener {
 
     private static final Log log = LogFactory.getLog(EventStreamListenerImpl.class);
+
     @Override
     public void removedEventStream(int tenantId, String streamName, String streamVersion) {
 
         CarbonEventProcessorService carbonEventProcessorService = EventProcessorValueHolder.getEventProcessorService();
         String streamNameWithVersion = DataBridgeCommonsUtils.generateStreamId(streamName, streamVersion);
-        carbonEventProcessorService.deactivateActiveExecutionPlanConfigurations(streamNameWithVersion, tenantId);
+        carbonEventProcessorService.deactivateActiveExecutionPlanConfigurations(streamNameWithVersion);
     }
 
     /**
@@ -47,7 +48,7 @@ public class EventStreamListenerImpl implements EventStreamListener {
         CarbonEventProcessorService carbonEventProcessorService = EventProcessorValueHolder.getEventProcessorService();
         String streamNameWithVersion = DataBridgeCommonsUtils.generateStreamId(streamName, streamVersion);
         try {
-            carbonEventProcessorService.activateInactiveExecutionPlanConfigurations(ExecutionPlanConfigurationFile.Status.WAITING_FOR_DEPENDENCY, streamNameWithVersion, tenantId);
+            carbonEventProcessorService.activateInactiveExecutionPlanConfigurations(ExecutionPlanConfigurationFile.Status.WAITING_FOR_DEPENDENCY, streamNameWithVersion);
         } catch (ExecutionPlanConfigurationException e) {
             log.error("Exception occurred while re-deploying the Event processor configuration files");
         }

--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/util/helper/EventProcessorHelper.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/util/helper/EventProcessorHelper.java
@@ -58,7 +58,7 @@ public class EventProcessorHelper {
         return executionPlanName;
     }
 
-    public static void validateExecutionPlan(String executionPlan, int tenantId)
+    public static void validateExecutionPlan(String executionPlan)
             throws ExecutionPlanConfigurationException, ExecutionPlanDependencyValidationException {
 
         String planName;
@@ -132,7 +132,7 @@ public class EventProcessorHelper {
                     throw new ExecutionPlanConfigurationException("Invalid stream version [" + streamIdComponents[1] + "] for stream name " + streamIdComponents[0] + " in execution plan: " + planName +
                             ". Stream version should match the regex '" + EventProcessorConstants.STREAM_VER_REGEX + "'");
                 }
-                validateIfStreamExists(streamIdComponents[0], streamIdComponents[1], tenantId);     // check if each Imported/Exported stream has actually being defined
+                validateIfStreamExists(streamIdComponents[0], streamIdComponents[1]);     // check if each Imported/Exported stream has actually being defined
                 if (exportedStreams.contains(importElementValue)) {                                   // check if same stream has been imported and exported.
                     throw new ExecutionPlanConfigurationException("Imported stream '" + importElementValue + "' is also among the exported streams. Hence the execution plan is invalid");
                 }
@@ -171,7 +171,7 @@ public class EventProcessorHelper {
                     throw new ExecutionPlanConfigurationException("Invalid stream version [" + streamIdComponents[1] + "] for stream name " + streamIdComponents[0] + " in execution plan: " + planName +
                             ". Stream version should match the regex '" + EventProcessorConstants.STREAM_VER_REGEX + "'");
                 }
-                validateIfStreamExists(streamIdComponents[0], streamIdComponents[1], tenantId);
+                validateIfStreamExists(streamIdComponents[0], streamIdComponents[1]);
                 if (importedStreams.contains(exportElementValue)) {
                     throw new ExecutionPlanConfigurationException("Exported stream '" + exportElementValue + "' is also among the imported streams. Hence the execution plan is invalid");
                 }
@@ -182,8 +182,7 @@ public class EventProcessorHelper {
     }
 
 
-    private static boolean validateIfStreamExists(String streamName, String streamVersion,
-                                                  int tenantId)
+    private static boolean validateIfStreamExists(String streamName, String streamVersion)
             throws ExecutionPlanConfigurationException, ExecutionPlanDependencyValidationException {
 
         EventStreamService eventStreamService = EventProcessorValueHolder.getEventStreamService();


### PR DESCRIPTION
Removing TenantId as Parameters in Event Processor Service operations. Instead get TenantId within the Event Processor Service itself.