### PR TITLE
Updating versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -762,7 +762,7 @@
         <!--<carbon.kernel.imp.pkg.version>[4.4.0, 4.5.0)</carbon.kernel.imp.pkg.version>-->
 
         <carbon.commons.version>4.4.7</carbon.commons.version>
-        <carbon.analytics.common.version>5.0.3</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.0.4</carbon.analytics.common.version>
 
         <!--CEP versions-->
         <siddhi.version>3.0.2</siddhi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -785,7 +785,7 @@
         <guava.version>14.0.1</guava.version>
         <snakeyaml.version>1.11</snakeyaml.version>
         <quartz.version>2.1.1.wso2v1</quartz.version>
-        <hadoop.client.version>2.6.0.wso2v1</hadoop.client.version>
+        <hadoop.client.version>2.6.0.wso2v2</hadoop.client.version>
         <ml.version>1.0.0</ml.version>
         <commons-math3.version>3.2</commons-math3.version>
         <scala.version>2.11.0</scala.version>


### PR DESCRIPTION
Updating hadoop client version and the released repo version for carbon-analytics-common. Please merge once carbon-analytics-common 5.0.4 has been released and not before.