### PR TITLE
Fixing https://wso2.org/jira/browse/CEP-1375

### DIFF
--- a/components/event-processor/org.wso2.carbon.event.processor.admin/pom.xml
+++ b/components/event-processor/org.wso2.carbon.event.processor.admin/pom.xml
@@ -95,6 +95,7 @@
                             <!--!javax.xml.namespace,-->
                             org.wso2.carbon.event.processor.core.*,
                             javax.xml.namespace; version=0.0.0,
+                            org.wso2.carbon.databridge.*;version="${carbon.analytics.common.range}",
                             *;resolution:=optional
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>

--- a/components/event-processor/org.wso2.carbon.event.processor.admin/pom.xml
+++ b/components/event-processor/org.wso2.carbon.event.processor.admin/pom.xml
@@ -95,7 +95,7 @@
                             <!--!javax.xml.namespace,-->
                             org.wso2.carbon.event.processor.core.*,
                             javax.xml.namespace; version=0.0.0,
-                            org.wso2.carbon.databridge.*;version="${carbon.analytics.common.range}",
+                            org.wso2.carbon.databridge.commons.*;version="${carbon.analytics.common.range}",
                             *;resolution:=optional
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>

--- a/components/event-processor/org.wso2.carbon.event.processor.core/pom.xml
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/pom.xml
@@ -102,6 +102,10 @@
             <groupId>org.wso2.carbon.analytics-common</groupId>
             <artifactId>org.wso2.carbon.event.processor.manager.commons</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
+            <artifactId>org.wso2.carbon.databridge.commons</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -144,6 +148,7 @@
                             javax.xml.namespace; version=0.0.0,
                             org.wso2.siddhi.*,
                             org.wso2.carbon.event.processor.common.*,
+                            org.wso2.carbon.databridge.*;version="${carbon.analytics.common.range}",
                             *;resolution:=optional
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>

--- a/components/event-processor/org.wso2.carbon.event.processor.core/pom.xml
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/pom.xml
@@ -148,7 +148,7 @@
                             javax.xml.namespace; version=0.0.0,
                             org.wso2.siddhi.*,
                             org.wso2.carbon.event.processor.common.*,
-                            org.wso2.carbon.databridge.*;version="${carbon.analytics.common.range}",
+                            org.wso2.carbon.databridge.commons.*;version="${carbon.analytics.common.range}",
                             *;resolution:=optional
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>

--- a/pom.xml
+++ b/pom.xml
@@ -763,6 +763,7 @@
 
         <carbon.commons.version>4.4.8</carbon.commons.version>
         <carbon.analytics.common.version>5.0.6-SNAPSHOT</carbon.analytics.common.version>
+        <carbon.analytics.common.range>[5.0.6,6.0.0)</carbon.analytics.common.range>
 
         <!--CEP versions-->
         <siddhi.version>3.0.3-SNAPSHOT</siddhi.version>


### PR DESCRIPTION
org.wso2.carbon.event.processor.admin and org.wso2.carbon.event.processor.core gets wired with different org.wso2.carbon.analytics-common version