### PR TITLE
Fixing osgi issues

### DIFF
--- a/components/event-processor/org.wso2.carbon.event.processor.common/pom.xml
+++ b/components/event-processor/org.wso2.carbon.event.processor.common/pom.xml
@@ -114,6 +114,7 @@
                         <Import-Package>
                             !javax.xml.namespace,
                             javax.xml.namespace; version=0.0.0,
+			    org.apache.thrift;version="[0.8.0.wso2v1,0.9.0)",
                             com.lmax.disruptor.*;version="${disruptor.version.range}",
                             *;resolution:=optional,
                         </Import-Package>


### PR DESCRIPTION
When multiple versions of thrift is available, event-processing component gets bound to the latest version, creating issues. Ideally it should be within the specified range in order for the bundle to work properly.