### PR TITLE
Fixing https://wso2.org/jira/browse/CEP-1541

### DIFF
--- a/components/event-processor/org.wso2.carbon.event.processor.common/src/main/java/org/wso2/carbon/event/processor/common/storm/component/TriggerSpout.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.common/src/main/java/org/wso2/carbon/event/processor/common/storm/component/TriggerSpout.java
@@ -1,0 +1,79 @@
+package org.wso2.carbon.event.processor.common.storm.component;
+
+import backtype.storm.spout.SpoutOutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.topology.base.BaseRichSpout;
+import backtype.storm.tuple.Fields;
+import org.apache.log4j.Logger;
+import org.wso2.siddhi.core.ExecutionPlanRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.stream.output.StreamCallback;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Spout to hold a siddhi trigger. There will be one instance of this class per trigger.
+ *
+ */
+public class TriggerSpout extends BaseRichSpout {
+    public static final String TRIGGER_TIME_FIELD_NAME = "triggered_time";
+    String triggerId;
+    String triggerDefinition;
+    SpoutOutputCollector outputCollector;
+    private transient SiddhiManager siddhiManager;
+    private transient ExecutionPlanRuntime executionPlanRuntime;
+    private static transient Logger log = Logger.getLogger(TriggerSpout.class);
+    String logPrefix;
+
+    public  TriggerSpout(String triggerId, String triggerDefinition, String executionPlanName, int tenantId){
+        this.triggerId  = triggerId;
+        this.triggerDefinition = triggerDefinition;
+        this.logPrefix = "[" + tenantId + ":" + executionPlanName + ":" + triggerId + "] ";
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer outputFieldsDeclarer) {
+        List<String> list = new ArrayList<String>();
+        list.add(0,"_timestamp");
+        list.add(0, TRIGGER_TIME_FIELD_NAME);
+        Fields fields = new Fields(list);
+
+        outputFieldsDeclarer.declareStream(triggerId, fields);
+    }
+
+    @Override
+    public void open(Map map, TopologyContext topologyContext, final SpoutOutputCollector spoutOutputCollector) {
+        this.outputCollector = spoutOutputCollector;
+
+        siddhiManager = new SiddhiManager();
+        String fullQueryExpression = triggerDefinition;
+        executionPlanRuntime = siddhiManager.createExecutionPlanRuntime(fullQueryExpression);
+
+        executionPlanRuntime.addCallback(triggerId, new StreamCallback() {
+
+                @Override
+                public void receive(Event[] events) {
+                    for (Event event : events) {
+                        Object[] eventData = Arrays.copyOf(event.getData(), event.getData().length + 1);
+                        eventData[event.getData().length] = event.getTimestamp();
+                        outputCollector.emit(triggerId, Arrays.asList(eventData));
+
+                        if (log.isDebugEnabled()) {
+                            log.debug(logPrefix + "Trigger Event Emitted :" + Arrays.deepToString(eventData));
+                        }
+                    }
+                }
+            });
+        executionPlanRuntime.start();
+    }
+
+    @Override
+    public void nextTuple() {
+
+    }
+}

--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/storm/compiler/SiddhiQLStormQuerySplitter.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/storm/compiler/SiddhiQLStormQuerySplitter.java
@@ -77,31 +77,7 @@ public class SiddhiQLStormQuerySplitter extends SiddhiQLBaseVisitor {
 
         return eventTableList;
     }
-
-    public static List<String> getTriggerList(String source){
-        ANTLRInputStream input = new ANTLRInputStream(source);
-        SiddhiQLLexer lexer = new SiddhiQLLexer(input);
-        lexer.removeErrorListeners();
-        lexer.addErrorListener(SiddhiErrorListener.INSTANCE);
-
-        CommonTokenStream tokens = new CommonTokenStream(lexer);
-        SiddhiQLParser parser = new SiddhiQLParser(tokens);
-        parser.removeErrorListeners();
-        parser.addErrorListener(SiddhiErrorListener.INSTANCE);
-        ParseTree tree = parser.parse();
-
-        SiddhiQLVisitor eval = new SiddhiQLStormQuerySplitter();
-        List<String> triggerList = new ArrayList<>();
-        SiddhiQLParser.Execution_planContext ctx = (((SiddhiQLParser.ParseContext)tree).execution_plan());
-
-        for (SiddhiQLParser.Definition_triggerContext executionElementContext : ctx.definition_trigger()) {
-            String triggerDefinition =  (String) eval.visit(executionElementContext);
-            triggerList.add(triggerDefinition);
-        }
-
-        return triggerList;
-    }
-
+    
     /**
      * {@inheritDoc}
      * <p/>

--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/storm/compiler/SiddhiQLStormQuerySplitter.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/storm/compiler/SiddhiQLStormQuerySplitter.java
@@ -74,7 +74,32 @@ public class SiddhiQLStormQuerySplitter extends SiddhiQLBaseVisitor {
             String query =  (String) eval.visit(executionElementContext);
             eventTableList.add(query);
         }
+
         return eventTableList;
+    }
+
+    public static List<String> getTriggerList(String source){
+        ANTLRInputStream input = new ANTLRInputStream(source);
+        SiddhiQLLexer lexer = new SiddhiQLLexer(input);
+        lexer.removeErrorListeners();
+        lexer.addErrorListener(SiddhiErrorListener.INSTANCE);
+
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        SiddhiQLParser parser = new SiddhiQLParser(tokens);
+        parser.removeErrorListeners();
+        parser.addErrorListener(SiddhiErrorListener.INSTANCE);
+        ParseTree tree = parser.parse();
+
+        SiddhiQLVisitor eval = new SiddhiQLStormQuerySplitter();
+        List<String> triggerList = new ArrayList<>();
+        SiddhiQLParser.Execution_planContext ctx = (((SiddhiQLParser.ParseContext)tree).execution_plan());
+
+        for (SiddhiQLParser.Definition_triggerContext executionElementContext : ctx.definition_trigger()) {
+            String triggerDefinition =  (String) eval.visit(executionElementContext);
+            triggerList.add(triggerDefinition);
+        }
+
+        return triggerList;
     }
 
     /**

--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/storm/util/ComponentInfoHolder.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/storm/util/ComponentInfoHolder.java
@@ -25,7 +25,7 @@ public class ComponentInfoHolder {
 
 
 
-    public enum ComponentType {EVENT_RECEIVER_SPOUT, SIDDHI_BOLT, EVENT_PUBLISHER_BOLT;}
+    public enum ComponentType {EVENT_RECEIVER_SPOUT, SIDDHI_BOLT, EVENT_PUBLISHER_BOLT, TRIGGER_SPOUT;}
 
     private ComponentType componentType;
     private String componentName = null;

--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/util/EventProcessorConstants.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/util/EventProcessorConstants.java
@@ -72,12 +72,15 @@ public class EventProcessorConstants {
     public static final String OPENING_BRACKETS = " ( ";
     public static final String SPACE = " ";
     public static final String COMMA = ", ";
-    public static final String CLOSING_BRACKETS = ");";
+    public static final String SEMICOLEN = ";";
+    public static final String CLOSING_BRACKETS = ")" + SEMICOLEN;
     public static final String STORM_QUERY_PLAN = "storm-query-plan";
     public static final String INPUT_STREAMS = "input-streams";
     public static final String TABLE_DEFINITIONS = "table-definitions";
     public static final String OUTPUT_STREAMS = "output-streams";
+    public static final String OUTPUT_STREAM = "output-stream";
     public static final String EVENT_PROCESSOR_TAG = "event-processor";
+    public static final String TRIGGER_TAG = "trigger";
     public static final String SIDDHI_BOLT = "SiddhiBolt";
     public static final String QUERIES = "queries";
     public static final String EVENT_RECEIVER = "event-receiver";
@@ -85,8 +88,11 @@ public class EventProcessorConstants {
     public static final String STREAMS = "streams";
     public static final String STREAM = "stream";
     public static final String DEFINE_STREAM = "define stream ";
+    public static final String DEFINE_TRIGGER = "define trigger ";
     public static final String EVENT_PUBLISHER = "event-publisher";
+    public static final String TRIGGER_DEFINITION = "trigger-definition";
     public static final String EVENT_PUBLISHER_BOLT = "EventPublisherBolt";
+    public static final String TRIGGER_SPOUT = "TriggerSpout";
     public static final String PARALLEL = "parallel";
     public static final String RECEIVER_PARALLELISM = "receiverParallelism";
     public static final String PUBLISHER_PARALLELISM = "publisherParallelism";
@@ -95,6 +101,9 @@ public class EventProcessorConstants {
     public static final String DIST = "dist";
     public static final String EXEC_GROUP = "execGroup";
     public static final String ENFORCE_PARALLELISM = "enforceParallel";
+    public static final String TRIGGER_AT_EVERY = " at every ";
+    public static final String TRIGGER_AT= " at ";
+    public static final String SECOND = " sec";
 
     // Annotations, Annotation Names and relevant tokens.
     public static final String ANNOTATION_PLAN = "Plan";

--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/util/EventProcessorUtil.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/util/EventProcessorUtil.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.siddhi.core.util.SiddhiConstants;
 import org.wso2.siddhi.query.api.definition.Attribute;
+import org.wso2.siddhi.query.api.definition.TriggerDefinition;
 import org.wso2.siddhi.query.api.exception.DuplicateAttributeException;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -299,6 +300,26 @@ public class EventProcessorUtil {
         }
         builder.deleteCharAt(builder.length() - 2);         //remove last comma
         builder.append(EventProcessorConstants.CLOSING_BRACKETS);
+        return builder.toString();
+    }
+
+    public static String getTriggerDefinitionString(TriggerDefinition triggerDefinition){
+        StringBuilder builder = new StringBuilder();
+        builder.append(EventProcessorConstants.DEFINE_TRIGGER);
+        builder.append(triggerDefinition.getId());
+
+
+        Long atEvery = triggerDefinition.getAtEvery();
+        if (atEvery != null){
+            builder.append(EventProcessorConstants.TRIGGER_AT_EVERY);
+            builder.append(atEvery/1000); // All time units are in milliseconds in trigger definition object. Convert it into seconds
+            builder.append(EventProcessorConstants.SECOND);
+        } else{
+            builder.append(EventProcessorConstants.TRIGGER_AT);
+            builder.append("'" + triggerDefinition.getAt() + "'");
+        }
+
+        builder.append(EventProcessorConstants.SEMICOLEN);
         return builder.toString();
     }
 


### PR DESCRIPTION
This is the fix for allowing triggers to be used with storm. The fix was to create new spout for each trigger. Trigger spouts will only contain the trigger definition as the siddhi query and will emit the periodic events generated by the trigger. Multiple quarries   can consume the stream generated by the trigger spout.

Spout will be named as TriggerSpout_<TriggerName>. So that you should be able to see an additional spout when you define a trigger with the name beginning TriggerSpout_.