### PR TITLE
Disabled trace in Geo-Publisher-WebSocketLocal-FusedSpacialEvent

### DIFF
--- a/features/geo-dashboard/org.wso2.carbon.geo.dashboard.feature/src/main/capp/Geo-Publisher-WebSocketLocal-FusedSpacialEvent_1.0.0/Geo-Publisher-WebSocketLocal-FusedSpacialEvent-1.0.0.xml
+++ b/features/geo-dashboard/org.wso2.carbon.geo.dashboard.feature/src/main/capp/Geo-Publisher-WebSocketLocal-FusedSpacialEvent_1.0.0/Geo-Publisher-WebSocketLocal-FusedSpacialEvent-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <eventPublisher name="Geo-Publisher-WebSocketLocal-FusedSpacialEvent"
-  statistics="disable" trace="enable" xmlns="http://wso2.org/carbon/eventpublisher">
+  statistics="disable" trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
   <from streamName="org.wso2.geo.FusedSpatialEvent" version="1.0.0"/>
   <mapping customMapping="enable" type="json">
     <inline>


### PR DESCRIPTION
Disabled trace in Geo-Publisher-WebSocketLocal-FusedSpacialEvent event publisher. Otherwise this might cause end up having huge trace log files.