### PR TITLE
HTTP-400 on config event stream request

### DIFF
--- a/components/event-simulator/org.wso2.carbon.event.simulator.ui/src/main/resources/web/eventsimulator/js/stream_configuration.js
+++ b/components/event-simulator/org.wso2.carbon.event.simulator.ui/src/main/resources/web/eventsimulator/js/stream_configuration.js
@@ -125,11 +125,9 @@ function sendConfiguration(form){
 
     jQuery.ajax({
         type: "POST",
-        url: "../eventsimulator/sendConfigValues_ajaxprocessor.jsp?jsonData=" + jsonString + "",
+        url: "../eventsimulator/sendConfigValues_ajaxprocessor.jsp",
         beforeSend: function(xhr){xhr.setRequestHeader(token_name, token_value);},
-        data: {},
-        contentType: "application/json; charset=utf-8",
-        dataType: "text",
+        data: {jsonData : jsonString},
         async: false,
 
         success:function(msg){


### PR DESCRIPTION
Sending json string as query parameter cause HTTP-400 response. Parameter moved to form fields in POST request