### PR TITLE
Event notifier update

### DIFF
--- a/components/geo-dashboard/org.wso2.carbon.siddhi.geo.event.notifier/src/main/java/org/wso2/carbon/siddhi/geo/event/notifier/NotifyAlert.java
+++ b/components/geo-dashboard/org.wso2.carbon.siddhi.geo.event.notifier/src/main/java/org/wso2/carbon/siddhi/geo/event/notifier/NotifyAlert.java
@@ -122,6 +122,9 @@ public class NotifyAlert extends FunctionExecutor{
         if (informationBuffer.containsKey(id) && !informationBuffer.get(id).equals(currentInformation)) {
             returnValue = true;
         }
+        if (!informationBuffer.containsKey(id)) {
+                returnValue = true;
+        }
         informationBuffer.put(id, currentInformation);
         return returnValue;
     }

--- a/components/geo-dashboard/org.wso2.carbon.siddhi.geo.event.notifier/src/main/java/org/wso2/carbon/siddhi/geo/event/notifier/NotifyAlert.java
+++ b/components/geo-dashboard/org.wso2.carbon.siddhi.geo.event.notifier/src/main/java/org/wso2/carbon/siddhi/geo/event/notifier/NotifyAlert.java
@@ -93,6 +93,9 @@ public class NotifyAlert extends FunctionExecutor{
             if (informationBuffer.containsKey(id) && !informationBuffer.get(id).equals(currentInformation)) {
                 returnValue = true;
             }
+            if (!informationBuffer.containsKey(id)) {
+                returnValue = true;
+            }
             informationBuffer.put(id, currentInformation);
         }
         if (data.length == 3) {


### PR DESCRIPTION
## Purpose
> Resolving the issue of current event notifier not generating notifications if the device is outside the fence area in the beginning. 

## Goals
> Adding the ability of generating notifications when the device is outside fence area in the beginning. 

## Approach
> If the 'informationBuffer' does not contain the device ID, 'returnValue' is set to true.  

## User stories
> N/A

## Release note
> Fixing a minor issue of event notifier.

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK version: java 1.8.0_144
Operating System: Linux Ubuntu
Databases: H2
Browser version: Google Chrome 62.0.3202.89 
 
## Learning
> N/A