### PR TITLE
Make carbon-event-processing buildable in Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -725,7 +725,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.0</version>
+                    <version>0.8.4</version>
                     <executions>
                         <execution>
                             <id>default-prepare-agent</id>


### PR DESCRIPTION
## Purpose
Make carbon-event-processing buildable in Java 11

## Goals
Make carbon-event-processing buildable in Java 11

## Approach
Make carbon-event-processing buildable in Java 11

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A