### PR TITLE
Remove Hazelcast

### DIFF
--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/ds/EventProcessorServiceDS.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/ds/EventProcessorServiceDS.java
@@ -15,10 +15,6 @@
  */
 package org.wso2.carbon.event.processor.core.internal.ds;
 
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.MemberAttributeEvent;
-import com.hazelcast.core.MembershipEvent;
-import com.hazelcast.core.MembershipListener;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
@@ -124,41 +120,6 @@ public class EventProcessorServiceDS {
     protected void unsetEventStreamService(EventStreamService eventStreamService) {
 
         EventProcessorValueHolder.registerEventStreamService(null);
-    }
-
-    @Reference(
-            name = "hazelcast.instance.service",
-            service = com.hazelcast.core.HazelcastInstance.class,
-            cardinality = ReferenceCardinality.OPTIONAL,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetHazelcastInstance")
-    protected void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
-
-        EventProcessorValueHolder.registerHazelcastInstance(hazelcastInstance);
-        hazelcastInstance.getCluster().addMembershipListener(new MembershipListener() {
-
-            @Override
-            public void memberAdded(MembershipEvent membershipEvent) {
-
-            }
-
-            @Override
-            public void memberRemoved(MembershipEvent membershipEvent) {
-
-            }
-
-            @Override
-            public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
-
-            }
-        });
-        EventProcessorValueHolder.getEventProcessorService().notifyServiceAvailability(EventProcessorConstants
-                .HAZELCAST_INSTANCE);
-    }
-
-    protected void unsetHazelcastInstance(HazelcastInstance hazelcastInstance) {
-
-        EventProcessorValueHolder.registerHazelcastInstance(null);
     }
 
     @Reference(

--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/ds/EventProcessorValueHolder.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/ds/EventProcessorValueHolder.java
@@ -15,7 +15,6 @@
  */
 package org.wso2.carbon.event.processor.core.internal.ds;
 
-import com.hazelcast.core.HazelcastInstance;
 import org.apache.axis2.context.ConfigurationContext;
 import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.event.processor.core.internal.CarbonEventProcessorManagementService;
@@ -34,7 +33,6 @@ public class EventProcessorValueHolder {
     private static CarbonEventProcessorService eventProcessorService;
     private static EventManagementService eventManagementService;
     private static EventStreamService eventStreamService;
-    private static HazelcastInstance hazelcastInstance;
     private static UserRealm userRealm;
     private static DataSourceService dataSourceService;
     private static ServerConfigurationService serverConfiguration;
@@ -59,14 +57,6 @@ public class EventProcessorValueHolder {
 
     public static CarbonEventProcessorService getEventProcessorService() {
         return eventProcessorService;
-    }
-
-    public static void registerHazelcastInstance(HazelcastInstance hazelcastInstance) {
-        EventProcessorValueHolder.hazelcastInstance = hazelcastInstance;
-    }
-
-    public static HazelcastInstance getHazelcastInstance() {
-        return hazelcastInstance;
     }
 
 //    public static DataAccessService getDataAccessService() {

--- a/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/util/EventProcessorConstants.java
+++ b/components/event-processor/org.wso2.carbon.event.processor.core/src/main/java/org/wso2/carbon/event/processor/core/internal/util/EventProcessorConstants.java
@@ -65,7 +65,6 @@ public class EventProcessorConstants {
     public static final String META_PREFIX = "meta_";
     public static final String CORRELATION_PREFIX = "correlation_";
 
-    public static final String HAZELCAST_INSTANCE = "hazelcast.instance";
     public static final String NO_DEPENDENCY_INFO_MSG = "No dependency information available for this event formatter";
 
     // For storm query plan builder.

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,12 @@
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.core</artifactId>
                 <version>${carbon.kernel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.wso2.orbit.com.hazelcast</groupId>
+                        <artifactId>hazelcast</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>


### PR DESCRIPTION
## Purpose
As we have deprecated the Hazelcast based distributed caching use cases in APIM, removing the Hazelcast dependency from carbon-event-processing repository.

Fixes wso2/api-manager#478