### PR TITLE
Remove siddhi-extension-event-table and hadoop dependencies

### DIFF
--- a/features/event-processor/org.wso2.carbon.event.processor.server.feature/pom.xml
+++ b/features/event-processor/org.wso2.carbon.event.processor.server.feature/pom.xml
@@ -104,10 +104,6 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.siddhi</groupId>
-            <artifactId>siddhi-extension-event-table</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.siddhi</groupId>
             <artifactId>siddhi-extension-eval-script</artifactId>
         </dependency>
         <dependency>
@@ -164,10 +160,6 @@
             <artifactId>quartz</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.org.apache.hadoop</groupId>
-            <artifactId>hadoop-client</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
@@ -194,10 +186,6 @@
         <dependency>
             <groupId>org.json.wso2</groupId>
             <artifactId>json</artifactId>
-        </dependency>
-	    <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.wso2</groupId>
@@ -283,9 +271,6 @@
                                     org.wso2.siddhi:siddhi-extension-string:${siddhi.version}
                                 </bundleDef>
                                 <bundleDef>
-                                    org.wso2.siddhi:siddhi-extension-event-table:${siddhi.version}
-                                </bundleDef>
-                                <bundleDef>
                                     org.wso2.siddhi:siddhi-extension-eval-script:${siddhi.version}
                                 </bundleDef>
                                 <bundleDef>
@@ -308,10 +293,6 @@
                                 </bundleDef>
                                 <bundleDef>
                                     org.wso2.siddhi:siddhi-extension-markov-models:${siddhi.version}
-                                </bundleDef>
-
-                                <bundleDef>
-                                    org.wso2.orbit.org.apache.hadoop:hadoop-client:${hadoop.client.version}
                                 </bundleDef>
                                 <bundleDef>
                                     org.apache.commons:commons-math3:${commons-math3.version}

--- a/pom.xml
+++ b/pom.xml
@@ -455,18 +455,6 @@
                 <artifactId>siddhi-extension-string</artifactId>
                 <version>${siddhi.version}</version>
             </dependency>
-
-            <!-- Siddhi Event Table extension -->
-            <dependency>
-                <groupId>org.wso2.siddhi</groupId>
-                <artifactId>siddhi-extension-event-table</artifactId>
-                <version>${siddhi.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-common</artifactId>
-                <version>${hadoop.common.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.apache.tomcat.wso2</groupId>
                 <artifactId>jdbc-pool</artifactId>


### PR DESCRIPTION
## Purpose
To get rid of the below errors occurred when building product-apim after upgrading kernel to 4.7.1 and identity components to IS-6.0.0 related versions.

Error 1:
"Installation failed.
Cannot complete the install because one or more required items could not be found.
 Software being installed: WSO2 Carbon - Event Flow Feature 2.3.2 (org.wso2.carbon.event.flow.feature.group 2.3.2)
 Missing requirement: hadoop-client 2.7.2.wso2v1 (hadoop-client 2.7.2.wso2v1) requires 'package org.apache.tools.ant [0.0.0,1.0.0)' but it could not be found
 Cannot satisfy dependency:
  From: WSO2 Carbon - Event Flow Feature 2.3.2 (org.wso2.carbon.event.flow.feature.group 2.3.2)
  To: org.wso2.carbon.event.flow.server.feature.group [2.3.2]
 Cannot satisfy dependency:
  From: WSO2 Carbon - Event Flow Core Feature 2.3.2 (org.wso2.carbon.event.flow.server.feature.group 2.3.2)
  To: org.wso2.carbon.event.processor.server.feature.group [2.3.2,2.4.0)
 Cannot satisfy dependency:
  From: WSO2 Carbon - Event Processor Server Feature 2.3.2 (org.wso2.carbon.event.processor.server.feature.group 2.3.2)
  To: hadoop-client [2.7.2.wso2v1]
Application failed, log file location: /private/var/folders/d9/fmcy04z96l1c2dbww3j3mjg00000gn/T/tycho-p2-runtime16404781074881309109.tmp/configuration/1662540896428.log"

Error 2:
"Cannot complete the install because one or more required items could not be found.
 Software being installed: WSO2 Carbon - Event Flow Feature 2.3.3 (org.wso2.carbon.event.flow.feature.group 2.3.3)
 Missing requirement: siddhi-extension-event-table 3.2.8 (siddhi-extension-event-table 3.2.8) requires 'package org.apache.hadoop.util.bloom 2.6.0' but it could not be found
 Cannot satisfy dependency:
  From: WSO2 Carbon - Event Flow Feature 2.3.3 (org.wso2.carbon.event.flow.feature.group 2.3.3)
  To: org.wso2.carbon.event.flow.server.feature.group [2.3.3]
 Cannot satisfy dependency:
  From: WSO2 Carbon - Event Flow Core Feature 2.3.3 (org.wso2.carbon.event.flow.server.feature.group 2.3.3)
  To: org.wso2.carbon.event.processor.server.feature.group [2.3.3,2.4.0)
 Cannot satisfy dependency:
  From: WSO2 Carbon - Event Processor Server Feature 2.3.3 (org.wso2.carbon.event.processor.server.feature.group 2.3.3)
  To: siddhi-extension-event-table [3.2.8]
Application failed, log file location: /private/var/folders/d9/fmcy04z96l1c2dbww3j3mjg00000gn/T/tycho-p2-runtime11642990640323664727.tmp/configuration/1662975431501.log"
