### PR TITLE
Upgrade carbon-analytics-commons, guava and snakeyaml versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -921,7 +921,7 @@
         <carbon.p2.plugin.version>1.5.4</carbon.p2.plugin.version>
 
         <carbon.event.processing.version>2.3.7-SNAPSHOT</carbon.event.processing.version>
-        <carbon.analytics.common.version>5.3.1</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.6</carbon.analytics.common.version>
         <carbon.analytics.common.range>[5.2.0, 6.0.0)</carbon.analytics.common.range>
         <siddhi.version>3.2.8</siddhi.version>
         <carbon.metrics.version>1.3.7</carbon.metrics.version>
@@ -938,8 +938,8 @@
         <disruptor.version.range>[3.0.0,4.0.0)</disruptor.version.range>
         <disruptor.orbit.version>3.4.2.wso2v1</disruptor.orbit.version>
         <antlr.version>4.5</antlr.version>
-        <guava.version>31.0.1-jre</guava.version>
-        <snakeyaml.version>1.11</snakeyaml.version>
+        <guava.version>32.1.2-jre</guava.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
         <quartz.version>2.1.1.wso2v1</quartz.version>
         <hadoop.client.version>2.7.2.wso2v1</hadoop.client.version>
         <ml.version>1.2.7</ml.version>


### PR DESCRIPTION
## Purpose
Upgrade following dependencies
- carbon.analytics.commons -> 5.3.6
- Guava -> 32.1.2-jre
- Snakeyaml -> 2.0
