### PR TITLE
Update commons-lang3 dependency to WSO2 version and adjust group ID

### DIFF
--- a/features/event-processor/org.wso2.carbon.event.processor.server.feature/pom.xml
+++ b/features/event-processor/org.wso2.carbon.event.processor.server.feature/pom.xml
@@ -160,7 +160,7 @@
             <artifactId>quartz</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
+            <groupId>org.wso2.orbit.org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <!--<dependency>-->
@@ -298,7 +298,7 @@
                                     org.apache.commons:commons-math3:${commons-math3.version}
                                 </bundleDef>
                                 <bundleDef>
-                                    org.apache.commons:commons-lang3:${commons-lang3.version}
+                                    org.wso2.orbit.org.apache.commons:commons-lang3:${commons-lang3.version}
                                 </bundleDef>
                                 <bundleDef>
                                     org.json.wso2:json:${json.version}

--- a/pom.xml
+++ b/pom.xml
@@ -479,7 +479,7 @@
                 <version>${siddhi.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.commons</groupId>
+                <groupId>org.wso2.orbit.org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
             </dependency>
@@ -953,7 +953,7 @@
         <scala.version>2.11.0</scala.version>
         <scalascriptengine.version>1.3.10</scalascriptengine.version>
         <geocoder.version>0.16_1</geocoder.version>
-        <commons-lang3.version>3.17.0</commons-lang3.version>
+        <commons-lang3.version>3.18.0.wso2v1</commons-lang3.version>
         <json-simple.version>1.1.1</json-simple.version>
         <json.version>3.0.0.wso2v7</json.version>
         <hadoop.common.version>2.6.0</hadoop.common.version>


### PR DESCRIPTION
This pull request updates the project to use the WSO2 Orbit version of the `commons-lang3` library instead of the standard Apache version, and also bumps its version. The changes ensure better compatibility with WSO2 dependencies across the codebase.

Dependency updates:

* Replaced the `org.apache.commons:commons-lang3` dependency with `org.wso2.orbit.org.apache.commons:commons-lang3` in both the main `pom.xml` and the event processor server feature module. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L482-R482) [[2]](diffhunk://#diff-835edde551f21ea360364469a162ded49c1e1337ad5f56e1d13750084e4513adL163-R163)
* Updated the `commons-lang3.version` property from `3.17.0` to `3.18.0.wso2v1` in the main `pom.xml` to use the WSO2 Orbit release.

Feature module alignment:

* Updated the bundle definition for `commons-lang3` in `org.wso2.carbon.event.processor.server.feature/pom.xml` to use the WSO2 Orbit group and version.